### PR TITLE
🤖 Update CTA to honest messaging and simplify contact form

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default function HomePage() {
   const handlePricingPlanClick = (planName: string) => {
     trackPricingPlanView(planName)
     if (planName === 'professional') {
-      handleStartTrialClick('pricing_section', 'professional')
+      handleRequestDemoClick('pricing_section', 'professional')
     } else {
       handleContactSalesClick('pricing_section', 'enterprise')
     }
@@ -154,13 +154,13 @@ export default function HomePage() {
         </p>
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button
-            id="btn-start-free-trial-hero"
-            data-ga-id="start_free_trial"
+            id="btn-request-demo-hero"
+            data-ga-id="request_demo"
             size="lg"
-            onClick={() => trackCTAClick('start_free_trial', 'Start Free Trial', '/hero', () => handleStartTrialClick('hero'))}
+            onClick={() => trackCTAClick('request_demo', 'Request Demo', '/hero', () => handleRequestDemoClick('hero'))}
             className="text-lg px-8"
           >
-            Start Free Trial
+            Request Demo
             <ArrowRight className="ml-2 h-5 w-5" />
           </Button>
           <Button size="lg" variant="outline" className="text-lg px-8" asChild>
@@ -170,7 +170,7 @@ export default function HomePage() {
           </Button>
         </div>
         <div className="mt-12 text-sm text-slate-500">
-          No credit card required • 14-day free trial • Setup in minutes
+          We will reach out a total of three times during business hours and delete your information if you do not respond.
         </div>
       </section>
 
@@ -272,12 +272,12 @@ export default function HomePage() {
                 </div>
               ))}
               <Button
-                id="btn-start-free-trial-pricing"
-                data-ga-id="start_free_trial"
+                id="btn-request-demo-pricing"
+                data-ga-id="request_demo"
                 className="w-full mt-6"
-                onClick={() => trackCTAClick('start_free_trial', 'Start Free Trial', '/pricing', () => handlePricingPlanClick('professional'))}
+                onClick={() => trackCTAClick('request_demo', 'Request Demo', '/pricing', () => handlePricingPlanClick('professional'))}
               >
-                Start Free Trial
+                Request Demo
               </Button>
             </CardContent>
           </Card>
@@ -330,7 +330,7 @@ export default function HomePage() {
           <p className="text-xl text-slate-300 mb-8 max-w-2xl mx-auto">
             Join hundreds of companies already using AgentPro to deliver exceptional customer experiences.
           </p>
-          <Button size="lg" className="bg-white text-slate-900 hover:bg-slate-100" onClick={() => handleStartTrialClick('cta_section')}>
+          <Button size="lg" className="bg-white text-slate-900 hover:bg-slate-100" onClick={() => handleRequestDemoClick('cta_section')}>
             Get Started Today
             <ArrowRight className="ml-2 h-5 w-5" />
           </Button>

--- a/src/components/contact-sales-dialog.tsx
+++ b/src/components/contact-sales-dialog.tsx
@@ -17,8 +17,7 @@ interface ContactSalesDialogProps {
 
 export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogProps) {
   const [formData, setFormData] = useState({
-    firstName: "",
-    lastName: "",
+    fullName: "",
     email: "",
     company: "",
     phone: "",
@@ -50,8 +49,7 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
     setTimeout(() => {
       setIsSubmitted(false)
       setFormData({
-        firstName: "",
-        lastName: "",
+        fullName: "",
         email: "",
         company: "",
         phone: "",
@@ -99,43 +97,31 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
             Get a personalized demo and see how AgentPro can transform your customer support.
             Our team will reach out within 24 hours.
           </DialogDescription>
+          <div className="mt-3 text-sm text-slate-500">
+            We will reach out a total of three times during business hours and delete your information if you do not respond.
+          </div>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-6 mt-6">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <Label htmlFor="firstName" className="flex items-center gap-2">
-                <Users className="h-4 w-4" />
-                First Name *
-              </Label>
-              <Input
-                id="firstName"
-                value={formData.firstName}
-                onChange={(e) => handleInputChange("firstName", e.target.value)}
-                placeholder="John"
-                required
-                className="border-slate-300 focus:border-blue-500"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="lastName" className="flex items-center gap-2">
-                Last Name *
-              </Label>
-              <Input
-                id="lastName"
-                value={formData.lastName}
-                onChange={(e) => handleInputChange("lastName", e.target.value)}
-                placeholder="Smith"
-                required
-                className="border-slate-300 focus:border-blue-500"
-              />
-            </div>
+          <div className="space-y-2">
+            <Label htmlFor="fullName" className="flex items-center gap-2">
+              <Users className="h-4 w-4" />
+              Full Name *
+            </Label>
+            <Input
+              id="fullName"
+              value={formData.fullName}
+              onChange={(e) => handleInputChange("fullName", e.target.value)}
+              placeholder="John Smith"
+              required
+              className="border-slate-300 focus:border-blue-500"
+            />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="email" className="flex items-center gap-2">
               <Mail className="h-4 w-4" />
-              Work Email *
+              Work Email (or provide phone)
             </Label>
             <Input
               id="email"
@@ -143,7 +129,6 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
               value={formData.email}
               onChange={(e) => handleInputChange("email", e.target.value)}
               placeholder="john@company.com"
-              required
               className="border-slate-300 focus:border-blue-500"
             />
           </div>
@@ -152,14 +137,13 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
             <div className="space-y-2">
               <Label htmlFor="company" className="flex items-center gap-2">
                 <Building className="h-4 w-4" />
-                Company *
+                Company (optional)
               </Label>
               <Input
                 id="company"
                 value={formData.company}
                 onChange={(e) => handleInputChange("company", e.target.value)}
                 placeholder="Acme Corp"
-                required
                 className="border-slate-300 focus:border-blue-500"
               />
             </div>
@@ -179,7 +163,7 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
             <div className="space-y-2">
               <Label htmlFor="phone" className="flex items-center gap-2">
                 <Phone className="h-4 w-4" />
-                Phone Number
+                Phone Number (or provide email)
               </Label>
               <Input
                 id="phone"
@@ -238,10 +222,10 @@ export function ContactSalesDialog({ open, onOpenChange }: ContactSalesDialogPro
               id="btn-request-demo-form"
               data-ga-id="request_demo"
               type="submit"
-              disabled={isSubmitting || !formData.firstName || !formData.lastName || !formData.email || !formData.company}
+              disabled={isSubmitting || !formData.fullName || (!formData.email && !formData.phone)}
               className="flex-1"
               onClick={() => {
-                if (!isSubmitting && formData.firstName && formData.lastName && formData.email && formData.company) {
+                if (!isSubmitting && formData.fullName && (formData.email || formData.phone)) {
                   trackCTAClick('request_demo', 'Request Demo', '/contact-form');
                 }
               }}


### PR DESCRIPTION
Here’s what I see in your current funnel: page_view=200, click_start_free=40, click_request_demo=2.

There’s a significant drop-off after the first step. The contact form triggered after click_start_free appears ineffective and should be simplified (fewer required fields, defer non-critical inputs). It is likely due to the deception of "free trial" followed by the users having to go and contact sales afterwards.

Proposed code changes:

- Replace "Start free trial" text with more honest messaging
- Reduce initial form fields to name + email/phone only
- Add a promise "We will reach out a total of three times during business hours and delete your information if you do not respond!"
- Make all other fields optional